### PR TITLE
Package name is a parameter

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,4 +15,5 @@ header_files:
   - ws.enable
 
 nginx_version: 1.13.4-1
+nginx_package_name: nginx-plus
 syslog_server: syslog.meh.com

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,6 @@ header_files:
   - gf.enable
   - ws.enable
 
-nginx_version: 1.13.4-1
+nginx_version: 1.13.4-1~{{ ansible_distribution_release }}
 nginx_package_name: nginx-plus
 syslog_server: syslog.meh.com

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: install
-  apt: name=nginx-plus={{ nginx_version }}~{{ ansible_distribution_release }}  state=present update_cache=yes allow_unauthenticated=yes
+  apt: name={{ nginx_package_name }}={{ nginx_version }}~{{ ansible_distribution_release }}  state=present update_cache=yes allow_unauthenticated=yes
   tags:
     - nginx
     - nginx-install

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: install
-  apt: name={{ nginx_package_name }}={{ nginx_version }}~{{ ansible_distribution_release }}  state=present update_cache=yes allow_unauthenticated=yes
+  apt: name={{ nginx_package_name }}={{ nginx_version }}  state=present update_cache=yes allow_unauthenticated=yes
   tags:
     - nginx
     - nginx-install


### PR DESCRIPTION
Turned package name into a parameter to support nginx (non -plus)
Moved the distribution release suffix into the default version number to be more flexible